### PR TITLE
fixed errordesc/3 to return not empty correct list

### DIFF
--- a/src/pgsql_util.erl
+++ b/src/pgsql_util.erl
@@ -252,7 +252,7 @@ errordesc(<<Code/integer, Rest/binary>>, Lines, AsBin) ->
 	      Unknown ->
 		  {Unknown, String}
 	  end,
-    errordesc(Rest1, [Msg|Lines]).
+    errordesc(Rest1, [Msg|Lines], AsBin).
 
 %%% Zip two lists together
 zip(List1, List2) ->


### PR DESCRIPTION
```
(ejabberd@localhost)1> {ok, DBRef} = pgsql:connect([{host, "127.0.0.1"}, {database, "xxx"}, {user, "xxx"}, {password, "xxx"}, {port, 5432}]).
```

Without patch:

```
(ejabberd@localhost)2> pgsql:squery(DBRef, "SELECT * FROM test;").
{ok,[{error,[]}]}
```

With patch:

```
(ejabberd@localhost)2> pgsql:squery(DBRef, "SELECT * FROM test;").
{ok,[{error,[{severity,'ERROR'},
             {code,"42P01"},
             {message,"relation \"test\" does not exist"},
             {position,15},
             {file,"parse_relation.c"},
             {line,984},
             {routine,"parserOpenTable"}]}]}
```
